### PR TITLE
Support for overclocked Raspberry Pi Zero W

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,7 @@ const BOARD_REVISIONS: { [ revision: string ]: string } = {
   '900093': VERSION_1_MODEL_ZERO,
   '920093': VERSION_1_MODEL_ZERO,
   '9000c1': VERSION_1_MODEL_ZERO_W,
+  '19000c1': VERSION_1_MODEL_ZERO_W, // Bad boy overclocked his Pi Zero W
   'a01040': VERSION_2_MODEL_B,
   'a01041': VERSION_2_MODEL_B,
   'a21041': VERSION_2_MODEL_B,


### PR DESCRIPTION
When you overclock your Raspberry Pi and use a certain combination of overclock params you'll void warranty and a bit in the SoC will be set permanently to 1. This also changes the revision number and breaks this package.