### PR TITLE
extend list of Raspberry Pi 4 board revision

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -80,6 +80,7 @@ const BOARD_REVISIONS: { [ revision: string ]: string } = {
   'a03111': VERSION_4_MODEL_B, // 1GB RAM
   'b03111': VERSION_4_MODEL_B, // 2GB RAM
   'c03111': VERSION_4_MODEL_B  // 4GB RAM
+  'c03112': VERSION_4_MODEL_B, // 4GB RAM
 };
 
 const B1: { [ wiringpi: number ]: IRaspiPinInfo } = {


### PR DESCRIPTION
Hello, I've got new raspi v4 with 4GB on board.
I've take a bug with ver of my board:
```
Unknown board revision c03112, assuming Raspberry Pi Zero/2/3 pinout. Unless you are running a compute module or very old RPi this should work fine. Please report this board revision in a GitHub issue at https://github.com/nebrius/raspi-board.
```
This PR can fix issue. If you need help (photos, more info, etc), please, let me know